### PR TITLE
removing the hard canvas dependency + easing the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contribution Guidelines
+
+Dear reader,
+
+you are about and willing to take part in shaping [the landing page of TransforMap](https://trello.com/c/T2DOJr60/26-landing-page). Please scan these lines for a quick overview of our method.
+
+## Collaboration via Pull Requests
+
+We highly favour collaboration methods inspired by [Pull Request](https://help.github.com/articles/using-pull-requests/) workflows.
+Further on we will assume you understand the basic terms, especially in your personal, perpetual learning practice.
+
+## Communication Channels
+
+Quickly get in touch with us via
+
+* preferably aforementioned **Pull Requests**, thus **code donations**!
+* [GitHub ![](https://img.shields.io/github/issues-raw/transformap/transformap.github.io.svg)](https://github.com/TransforMap/transformap.github.io/issues)
+* [![](http://img.shields.io/badge/gitter-%23transformap-green.svg)](https://gitter.com/transformap)
+* [![](http://img.shields.io/badge/freenode-%23transformap-green.svg)](irc://irc.freenode.net/transformap)
+* [![](http://img.shields.io/badge/twitter-@transformap-blue.svg)](https://twitter.com/transformap)
+
+Or to get in touch with the broader [TransforMap community](http://blog.14mmm.org/transformap-explained/), use
+
+* [![](http://img.shields.io/badge/trello-transformap-blue.svg)](https://trello.com/transformap)
+* [![](http://img.shields.io/badge/discourse-transformap-orange.svg)](http://discourse.transformap.co)
+* [![](http://img.shields.io/badge/EN%20%E2%9C%89%20global-@lists.14mmm.org-lightgrey.svg)](http://lists.14mmm.org/cgi-bin/mailman/listinfo/global)
+* [![](http://img.shields.io/badge/DE%20%E2%9C%89%20maps-@list.allmende.io-lightgrey.svg)](http://list.allmende.io/cgi-bin/mailman/listinfo/maps)
+
+## Ideas for the Future
+
+We are constantly seeking to adopt our development practice to established and widely accepted norms. Yet we cannot know everything, so please get in touch if something important is missing.
+
+### Native Web Apps
+
+As long as we consider the optimal deployment strategy for sustain- and scalable web services in the combination of independent, client side [Native Web Apps](http://blog.andyet.com/2015/01/22/native-web-apps) and highly flexible APIs like [Hydra](http://www.hydra-cg.com/), TransforMap aims at exploring the full potential of such [distributed](http://hyperboot.mx/), [offline](http://laniakea.im/) first services.
+
+A first idea could be to implement the [Hyperboot webapp bootloader](http://hyperboot.org/).
+Additionally, federated scenarios like the [Federated Wiki](http://fed.wiki.org/) will impose instructional questions.
+
+### Farer Future?
+
+* [BEM](https://en.bem.info/)
+* [bevry/base](/bevry/base)

--- a/README.md
+++ b/README.md
@@ -1,64 +1,89 @@
 # A TransforMap [DocPad](http://docpad.org) Project
 
-## Dependencies
+TransforMap aims at cartographing all alternative economies. [Read on the blog Why?](http://blog.14mmm.org/transformap-explained/)
 
-All commands have to be run within the root of the repository.
-Also consult `packages.json`.
+## Generating this site
 
-### For static site generation w/ DocPad
+### What you will need
 
-* `npm install --production`
+* A POSIX complaint Operating System that runs **Node.js**.
+* A **terminal** (console, command line, REPL) like `bash` which allows you to run commands by hand.
+If you are on Linux or Mac OS, you're most likely already equipped.
+* [`git`](http://git-scm.com/)
 
-#### `docpad install`
+Get started by opening such terminal and cloning this repository to your machine, i.e. by just copy-and-pasting the following commands.
 
-This will install the following modules:
+    git clone https://github.com/transformap/transformap.github.io.git ~/Repositories/github.com/transformap/transformap.github.io
 
-* `jade`
-* `livereload`
-* `ghpages`
-* (`stylus`) *not used yet*
+All following commands have to be run within the root of the repository. Change there with
 
-### Developer dependencies
+    cd ~/Repositories/github.com/transformap.github.io
 
-#### Favicon generation via Gulp
+Also make sure to have working `node` and `npm` executables within your `$PATH`.
+If `which node` and `which npm` don't show a thing for you, our best advice is to use [`nvm`](https://github.com/creationix/nvm#installation) for that.
 
-The initial idea and code for changing Favicons comes from [Federated Wiki](http://fed.wiki.org).
-Check the source!
+Also consult `packages.json` and the remaining source code for more details.
+Now there are two options for you to approach the code.
 
-#### `docpad install`
+### Requirements
 
-* `gulp`
+But before any, you also have to install `docpad` and `gulp` globally:
 
-#### `npm install`
+    npm install -g docpad gulp
 
-* `-g gulp` && `gulp`
-* `gulp-file`
-* `mkdirp`
-* `canvas`
+### Quick introduction for static hosting
 
-#### Dependencies for `canvas`
+If you don't trust the published output in the `master` branch, you can alter and recreate it yourself.
 
-* Ubuntu : `apt-get install pkg-config libpng-dev libgif-dev libfreetype6-dev libpixman-1-dev libcairo2-dev libjpeg-dev`
-* [Fedora](https://github.com/Automattic/node-canvas/wiki/Installation---Fedora) : `yum install cairo cairo-devel cairomm-devel libjpeg-turbo-devel pango pango-devel pangomm pangomm-devel giflib-devel`
-* OS X : https://github.com/Automattic/node-canvas
+    npm install --production
 
-## Run
+will install all required `docpad` and `gulp` modules.
 
-> `docpad run` + http://localhost:9778
+Then
 
-## Future to copy from
+    docpad generate
 
-* [bootstrap jade boilerplate](https://github.com/willianjusten/bootstrap-boilerplate/blob/master/src/templates/index.jade)
-* [bootstrap 3 & jade](https://github.com/ALT-F1/bootstrap3-jade-node-express-grunt)
-* [docpad-bootstrap-jade](https://github.com/docpad/twitter-bootstrap-jade.docpad/blob/master/docpad.coffee) w/o livereload
+produces the website output in `./out`.
+Use your favourite webserver (i.e. `python -m SimpleHTTPServer`, [`nws`](https://npm.im/nws) or [`http-server`](https://npm.im/http-server)) and browser to display the results.
 
-### Farest Future?
+Subsequently running `gulp` independently recreates the static assetts in `./out/files/`
 
-* BEM
-* https://github.com/bevry/base
-* API via http://hapijs.com/ ?
+`gulp clean` or `rm -rf out` help you to get rid of the already generated, respective outputs.
 
-* Please see [Trello for more](https://trello.com/c/T2DOJr60/26-landing-page).
+### Development and Deployment
+
+If you intend to advance further, use the following procedure instead.
+
+#### Development
+
+You can install all requirements for `stylus`, `livereload` and `gh-pages` by issuing
+
+    npm install
+
+followed by (an equivalent to `docpad run`)
+
+    npm start
+
+Then browse to [http://localhost:9778](http://localhost:9778/) to see the result.
+Now try editing some files, it's fun to watch the live reloader!
+
+#### Deployment
+
+As of the [plugin's documentation](https://github.com/docpad/docpad-plugin-ghpages#project-pages), deploying to GitHub Pages is as easy as
+
+    docpad deploy-ghpages --env static
+
+You can then access the website under the domain specified in `./src/files/CNAME`.
+
+> *Note* This repository's `source` and `master` branch layout targets a [GitHub Pages](https://pages.github.com/) deployment for an [Organization Pages site](https://help.github.com/articles/about-custom-domains-for-github-pages-sites/#how-github-pages-sites-use-custom-domains). Also see [User & Organization Pages](https://help.github.com/articles/user-organization-and-project-pages/#user--organization-pages).
+
+### Contributing
+
+Please refer to our [Contributing Guidelines](LICENCE.md) for information about
+
+* **Collaboration via Pull Requests**
+* **Communication Channels** and our
+* **Ideas for the Future**
 
 ---
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,74 +5,7 @@
 //        Browserify?              : http://www.100percentjs.com/just-like-grunt-gulp-browserify-now/
 
 var gulp = require('gulp');
-var file = require('gulp-file');
 var clean = require('gulp-clean');
-
-gulp.task('favicon', function() {
-  // https://github.com/fedwiki/wiki-plugin-favicon/blob/master/client/favicon.coffee
-  // https://github.com/fedwiki/wiki-node-server/blob/master/lib/server.coffee
-  // http://www.compileonline.com/try_coffeescript_online.php
-  var hsltorgb;
-
-  hsltorgb = function(h, s, l) {
-    var hue, m1, m2;
-    h = (h % 360) / 360;
-    m2 = l * (s + 1);
-    m1 = (l * 2) - m2;
-    hue = function(num) {
-      if (num < 0) {
-        num += 1;
-      } else if (num > 1) {
-        num -= 1;
-      }
-      if ((num * 6) < 1) {
-        return m1 + (m2 - m1) * num * 6;
-      } else if ((num * 2) < 1) {
-        return m2;
-      } else if ((num * 3) < 2) {
-        return m1 + (m2 - m1) * (2 / 3 - num) * 6;
-      } else {
-        return m1;
-      }
-    };
-    return [hue(h + 1 / 3) * 255, hue(h) * 255, hue(h - 1 / 3) * 255];
-  }
-
-  var favicon;
-
-  favicon = function() {
-    var Canvas = require('canvas');
-    var Image = Canvas.Image;
-    var canvas = new Canvas(32,32);
-    var ctx = canvas.getContext('2d');
-    light = hsltorgb(Math.random() * 360, .78, .50);
-    dark = hsltorgb(Math.random() * 360, .78, .25);
-    angle = 2 * (Math.random() - 0.5);
-    sin = Math.sin(angle);
-    cos = Math.cos(angle);
-    scale = Math.abs(sin) + Math.abs(cos);
-    colprep = function(col, p) {
-      return Math.floor(light[col] * p + dark[col] * (1 - p)) % 255;
-    };
-    for (x = _i = 0; _i <= 31; x = ++_i) {
-      for (y = _j = 0; _j <= 31; y = ++_j) {
-        p = sin >= 0 ? sin * x + cos * y : -sin * (31 - x) + cos * y;
-        p = p / 31 / scale;
-        ctx.fillStyle = "rgba(" + (colprep(0, p)) + ", " + (colprep(1, p)) + ", " + (colprep(2, p)) + ", 1)";
-        ctx.fillRect(x, y, 1, 1);
-      }
-    }
-    return canvas.toDataURL();
-  }
-
-  // Write generated canvas to disk.
-  // regex via http://stackoverflow.com/questions/16156402/canvas-todataurl-for-large-canvas
-
-
-  var buf = new Buffer(favicon().replace(/^data:image\/png;base64,/, ''), 'base64');
-
-  return file('favicon.ico', buf, { src: true }).pipe(gulp.dest('out/files'));
-});
 
 gulp.task('jquery', function() {
   return gulp.src('node_modules/jquery/dist/jquery.min.js')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TransforMap",
-  "version": "0.0.2",
+  "version": "0.0.2a",
   "description": "Landing page for TransforMap",
   "homepage": "http://transformap.co",
   "repository": {
@@ -16,9 +16,8 @@
     "docpad": "~6.69.1",
     "docpad-plugin-gulp": "~2.1.5",
     "docpad-plugin-jade": "~2.8.0",
-    "docpad-plugin-livereload": "~2.6.0",
-    "docpad-plugin-stylus": "~2.8.0",
     "gulp": "^3.8.10",
+    "gulp-clean": "^0.3.1",
     "jquery": "^2.1.1"
   },
   "main": "node_modules/docpad/bin/docpad-server",
@@ -26,10 +25,8 @@
     "start": "node_modules/docpad/bin/docpad-server"
   },
   "devDependencies": {
-    "canvas": "^1.1.6",
     "docpad-plugin-ghpages": "~2.4.3",
-    "gulp-clean": "^0.3.1",
-    "gulp-file": "^0.2.0",
-    "mkdirp": "^0.5.0"
+    "docpad-plugin-livereload": "~2.6.0",
+    "docpad-plugin-stylus": "~2.8.0"
   }
 }


### PR DESCRIPTION
This Pull Request features two commits which finally render this repository usable for externals.
The dependency on the `canvas` npm module, which itself has a long tail of dependencies, was just to unsuitable for different build environments (consider Linux <> Mac OS X) to generate a simple favicon.

Which happens almost itself in the browser, due to native `canvas` support.

---

@keikreutler Would you like to

1. review https://github.com/geopedia/geopedia.github.io locally by
  * [ ] generating the static assetts in the `--production` case before
  * [ ] running DocPad's development server to be certain to
2. merge this Pull Request?